### PR TITLE
bug: start/end of carousel 

### DIFF
--- a/libs/components/src/lib/Carousel/Carousel.style.tsx
+++ b/libs/components/src/lib/Carousel/Carousel.style.tsx
@@ -30,9 +30,17 @@ export const Slide: React.FC<React.PropsWithChildren<IContainerProps & IBaseProp
 )
 )
 
-export const SlideItemContainer: React.FC<React.PropsWithChildren<IBoxProps & IBaseProps>> = styled(Box)({
+// export const SlideItemContainer: React.FC<React.PropsWithChildren<IBoxProps & IBaseProps>> = styled(Box)({
+//         overflow: 'hidden'
+// })
+
+export const SlideItemContainer: React.FC<React.PropsWithChildren<IBoxProps & IBaseProps>> = styled(Box)(
+    ({ theme: { space }}) => ({
         overflow: 'hidden',
-})
+        paddingLeft: space.xlarge, 
+        paddingRight: space.xlarge
+    })
+)
 
 
 export const Wrapper: React.FC<React.PropsWithChildren<IBoxProps & IBaseProps>> = styled(Box)(


### PR DESCRIPTION
1. BUG: I don't think it's a bug, I had a read of the embla documentation and there's nothing about the finer details of going back and forth but if you test it, you'll see what I mean. I was going to also play with the `<Container>` width but that's standard throughout.
2. Instead of playing with shadow for UX, what about disabling the button to indicate there is nothing further left/right?